### PR TITLE
Build Sage with SAGE_INSTALL_GCC=yes

### DIFF
--- a/sage.yaml
+++ b/sage.yaml
@@ -5,7 +5,9 @@ branch: develop
 
 build: |
     export SAGE_FAT_BINARY=yes
-    export SAGE_PARALLEL_SPKG_BUILD=yes
+    # We need to install GCC because we need the gfortran library
+    # in the binary.
+    export SAGE_INSTALL_GCC=yes
     export MAKE='make -j{ncpu}'
     make || exit 1
     git gc --aggressive --prune=now
@@ -72,4 +74,3 @@ package:
           cp {path}/src/mac-app/sage-{version}-*.app.dmg $DMG
     files: *FILES_DEFAULT
     rewrite_path: *REWRITE_PATH_DEFAULT
-    


### PR DESCRIPTION
See https://trac.sagemath.org/ticket/23753

Also remove `export SAGE_PARALLEL_SPKG_BUILD=yes` which is no longer used (installing packages in parallel has been the default now for a long time).