### PR TITLE
Refresh macOS names and files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To build Sage binaries, just clone this repository and run
     git clone https://github.com/sagemath/binary-pkg.git
     cd binary-pkg
     make bdist-sage-linux     # If you are on Linux
-    make bdist-sage-osx       # If you are on OSX
+    make bdist-sage-macos     # If you are on macOS
     ls dist/                  # Built binaries will be in this directory
 
 Edit `sage.yaml` if you want to build something else than the current
@@ -37,7 +37,7 @@ patches any hard-coded paths. If there are more than one packaging
 configurations (see below), then the first one is used by default. Use
 the ``PACKAGE`` variable to pick another one, for example
 
-    make package-sage PACKAGE="OSX DMG image"
+    make package-sage PACKAGE="macOS disk image"
 
 In particular, see below for the different Mac packaging possibilities.
 
@@ -107,9 +107,9 @@ create a ``.tar.gz`` file, which is usually not what one wants on Mac.
 To create a Mac disk image file of the normal Sage command line distribution,
 use this package option:
 
-    make package-sage PACKAGE="OSX DMG image"
+    make package-sage PACKAGE="macOS disk image"
 
 To create a Mac disk image file of the Mac app bundle with menu items and
 which automatically launches a notebook, use
 
-    make package-sage PACKAGE="OSX mac app"
+    make package-sage PACKAGE="macOS app"

--- a/binary_pkg/os_information.py
+++ b/binary_pkg/os_information.py
@@ -9,7 +9,7 @@ import string
 
 def filename_sanitize(s):
     """
-    Sanitize the string so that it can be used as a part of a filename
+    Sanitize the string so that it can be used as a part of a filename.
     """
     allowed = string.ascii_letters + string.digits + '._-'
     def escape(ch):
@@ -18,22 +18,25 @@ def filename_sanitize(s):
 
 
 def osname():
+    """
+    Return a string for the operating system name.
+    """
     distname, version, extra = ld.linux_distribution()
     if distname:
         return filename_sanitize('{0}_{1}'.format(distname, version))
-    osx_version, empty, arch = platform.mac_ver()
-    if osx_version:
-        return filename_sanitize('OSX_{0}'.format(osx_version))
+    macos_version, empty, arch = platform.mac_ver()
+    if macos_version:
+        return filename_sanitize('macOS_{0}'.format(macos_version))
     raise RuntimeError('unknown distribution / os')
-        
+
 
 def arch():
+    """
+    Return a string for the architecture (processor family).
+    """
     return filename_sanitize(platform.machine())
-
 
 
 if __name__ == '__main__':
     print('OS name = "{0}"'.format(osname()))
     print('Architecture = "{0}"'.format(arch()))
-    
-    

--- a/sage.mk
+++ b/sage.mk
@@ -4,13 +4,13 @@ bdist-sage-linux:
 	@echo "Sage Binary Packages for Generic Linux"
 	$(MAKE) package-sage
 
-bdist-sage-osx:
-	@echo "Sage Binary Packages for OSX"
+bdist-sage-macos:
+	@echo "Sage Binary Packages for macOS"
 	$(MAKE) checkout-sage
 	$(MAKE) build-sage
 	$(MAKE) stage-sage PACKAGE="Full binary tarball"
 	$(MAKE) dist-sage  PACKAGE="Full binary tarball"
-	$(MAKE) stage-sage PACKAGE="OSX DMG image"
-	$(MAKE) dist-sage  PACKAGE="OSX DMG image"
-	$(MAKE) stage-sage PACKAGE="OSX mac app"
-	$(MAKE) dist-sage  PACKAGE="OSX mac app"
+	$(MAKE) stage-sage PACKAGE="macOS disk image"
+	$(MAKE) dist-sage  PACKAGE="macOS disk image"
+	$(MAKE) stage-sage PACKAGE="macOS app"
+	$(MAKE) dist-sage  PACKAGE="macOS app"

--- a/sage.yaml
+++ b/sage.yaml
@@ -60,21 +60,21 @@ package:
     rewrite_path: *REWRITE_PATH_DEFAULT
     strip: True
 
-  - name: OSX DMG image
+  - name: macOS disk image
     dist: |
           DMG={dist}/sage-{version}-{osname}-{arch}.dmg
           rm -f $DMG
-          # This is also the directory name under which OSX will mount it
+          # This is also the directory name under which macOS will mount it
           TARGET=$(dirname {path})/sage-{version}-{osname}-{arch}
           mkdir -p $TARGET
-          cp {path}/src/bin/sage-README-osx.txt $TARGET/README.txt
+          cp {path}/README.md $TARGET/README.txt
           cp -a {path} $TARGET/
           hdiutil create -srcfolder $TARGET -format UDBZ $DMG
           rm -rf $TARGET
     files: *FILES_DEFAULT
     rewrite_path: *REWRITE_PATH_DEFAULT
 
-  - name: OSX mac app
+  - name: macOS app
     dist: |
           DMG={dist}/sage-{version}-{osname}-{arch}.app.dmg
           rm -f $DMG

--- a/test/test_os_info.py
+++ b/test/test_os_info.py
@@ -17,7 +17,7 @@ class TestOsInformation(unittest.TestCase):
     def test_osname(self):
         self.assertIn(osname(), [
             'Fedora_26',
-            'OSX_10.11.3',
+            'macOS_10.15.7',
             'Ubuntu_16.04',
         ])
 

--- a/tools/bootstrap/bootstrap.sh
+++ b/tools/bootstrap/bootstrap.sh
@@ -7,7 +7,7 @@ MINICONDA_64=Miniconda3-py38_4.8.3
 case "$(uname -s)-$(uname -m)" in
     Darwin-x86_64)
         MINICONDA=$MINICONDA_64
-        ARCH=MacOSX-x86_64 ;;
+        ARCH=macOS-x86_64 ;;
     Linux-x86_64)
         MINICONDA=$MINICONDA_64
         ARCH=Linux-x86_64 ;;


### PR DESCRIPTION
- Change "OSX" to macOS throughout
- Copy main README.md instead of sage-README-osx.txt which was removed
  in [Sage Trac ticket 29383](https://trac.sagemath.org/ticket/29383),
  merged in Sage 9.1.beta9
- Add docstrings to two functions